### PR TITLE
Update readme to include installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,19 @@
 
 When using the Composer Autoloader if you need project files included prior to files autoloaded by any of your dependancies your out of luck. No longer!
 
+## Installation
+
+```bash
+composer require funkjedi/composer-include-files
+```
+
+## Usage
+
 Just add the files you need included using `"include_files"` and they will be include prior to any files included by your dependancies.
 
 ```json
 // composer.json (project)
 {
-    "require": {
-        "funkjedi/composer-include-files": "dev-master",
-    },
     "extra": {
         "include_files": [
             "/path/to/file/you/want/to/include",
@@ -32,7 +37,7 @@ But now we can use *Composer - Include Files Plugin* to have Composer include th
 {
     "require": {
         "laravel/framework": "^5.2",
-        "funkjedi/composer-include-files": "dev-master",
+        "funkjedi/composer-include-files": "^1.0",
     },
     "extra": {
         "include_files": [


### PR DESCRIPTION
Updated the readme to include installation instructions that can easily be copy and pasted. 

Packagist packages don't always follow the same vendor/package namespacing as the github username/repo convention. So providing this as part of the readme just makes things a little easier 👍 